### PR TITLE
Make `VetRepository` extend from `CassandraRepository` as stated in documentation

### DIFF
--- a/complete/src/main/java/com/example/accessingdatacassandra/VetRepository.java
+++ b/complete/src/main/java/com/example/accessingdatacassandra/VetRepository.java
@@ -2,8 +2,8 @@ package com.example.accessingdatacassandra;
 
 import java.util.UUID;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.cassandra.repository.CassandraRepository;
 
-public interface VetRepository extends CrudRepository<Vet, UUID> {	
+public interface VetRepository extends CassandraRepository<Vet, UUID> {
 	Vet findByFirstName(String username);
 }


### PR DESCRIPTION
In the documentation of this example it can be read:

> `VetRepository` extends the `CassandraRepository` interface and specifies types for the generic type parameters for both the value and the key that the repository works with — Vet and UUID, respectively.

However in the code it was extending `CrudRepository`, this changes the example to be in sync with the documentation.